### PR TITLE
fix(pagination): detect and handle DOM element reuse on paginated lists

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "rotector-extension-v2",

--- a/src/lib/types/changelog.ts
+++ b/src/lib/types/changelog.ts
@@ -70,6 +70,11 @@ export const CHANGELOGS: Changelog[] = [
 				type: 'fixed',
 				description:
 					'Report helper setting requirement - Auto-fill feature now checks if Advanced Violation Information is enabled and displays appropriate guidance'
+			},
+			{
+				type: 'fixed',
+				description:
+					'Pagination status indicators - Status indicators now properly update when navigating between pages on friends, followers, and following lists'
 			}
 		]
 	},


### PR DESCRIPTION
This commit fixes an issue where status indicators would not update when navigating between pages on friends, followers, and following lists. The root cause was Roblox's optimization of reusing DOM elements during pagination instead of destroying and recreating them.