### PR TITLE
refactor(types): replace numeric reason identifiers with string keys

### DIFF
--- a/src/components/features/ReportHelper.svelte
+++ b/src/components/features/ReportHelper.svelte
@@ -17,14 +17,14 @@
 	let processing = $state(false);
 
 	// Computed values
-	const isReportable = $derived(status ? '0' in (status.reasons || {}) : false);
+	const isReportable = $derived(status ? 'User Profile' in (status.reasons || {}) : false);
 
 	const reportableContent = $derived(
 		isReportable && status
 			? {
-					message: status.reasons?.['0']?.message || 'Inappropriate content detected',
-					evidence: status.reasons?.['0']?.evidence || [],
-					confidence: status.reasons?.['0']?.confidence || status.confidence || 0
+					message: status.reasons?.['User Profile']?.message || 'Inappropriate content detected',
+					evidence: status.reasons?.['User Profile']?.evidence || [],
+					confidence: status.reasons?.['User Profile']?.confidence || status.confidence || 0
 				}
 			: null
 	);

--- a/src/components/features/ReportPageManager.svelte
+++ b/src/components/features/ReportPageManager.svelte
@@ -125,12 +125,12 @@
 		}
 	}
 
-	// Check if user has profile violations (reason type 0)
+	// Check if user has User Profile violations
 	function hasUserProfileViolations(): boolean {
 		if (!userStatus || !userStatus.reasons) {
 			return false;
 		}
-		return '0' in userStatus.reasons;
+		return 'User Profile' in userStatus.reasons;
 	}
 
 	// Find and validate required form elements
@@ -251,7 +251,7 @@
 		// Build comment text
 		let commentText = t('report_page_manager_report_intro');
 
-		const profileReason = userStatus?.reasons?.['0'];
+		const profileReason = userStatus?.reasons?.['User Profile'];
 
 		if (profileReason?.message) {
 			commentText += t('report_page_manager_detected_issue_label') + profileReason.message + '\n\n';

--- a/src/components/status/Tooltip.svelte
+++ b/src/components/status/Tooltip.svelte
@@ -343,7 +343,7 @@
 	const reasonEntries = $derived.by((): FormattedReasonEntry[] => {
 		const currentStatus = activeStatus;
 		if (!currentStatus?.reasons || currentStatus.flagType === STATUS.FLAGS.SAFE) return [];
-		return formatViolationReasons(currentStatus.reasons, entityType);
+		return formatViolationReasons(currentStatus.reasons);
 	});
 
 	// Check if auto-translation should be enabled

--- a/src/lib/types/changelog.ts
+++ b/src/lib/types/changelog.ts
@@ -24,6 +24,11 @@ export const CHANGELOGS: Changelog[] = [
 			'This update improves extension stability and fixes several bugs related to groups showcase on profile pages.',
 		changes: [
 			{
+				type: 'changed',
+				description:
+					'Reason type identifiers - Simplified internal reason handling by using descriptive string keys instead of numeric codes'
+			},
+			{
 				type: 'fixed',
 				description:
 					'Groups showcase reliability - Fixed duplicate API requests and status indicator display issues when viewing groups on profile pages'

--- a/src/lib/types/constants.ts
+++ b/src/lib/types/constants.ts
@@ -8,42 +8,6 @@ export const STATUS = {
 		INTEGRATION: 4,
 		MIXED: 5,
 		PAST_OFFENDER: 6
-	},
-	USER_REASON_TYPES: {
-		USER_PROFILE: 0,
-		FRIEND_NETWORK: 1,
-		AVATAR_OUTFIT: 2,
-		GROUP_MEMBERSHIP: 3,
-		CONDO_ACTIVITY: 4,
-		CHAT_MESSAGES: 5,
-		GAME_FAVORITES: 6,
-		EARNED_BADGES: 7,
-		USER_CREATIONS: 8,
-		OTHER_REASONS: 9
-	},
-	GROUP_REASON_TYPES: {
-		MEMBER: 0,
-		PURPOSE: 1,
-		DESCRIPTION: 2,
-		SHOUT: 3
-	},
-	USER_REASON_TYPE_NAMES: {
-		0: 'User Profile',
-		1: 'Friend Network',
-		2: 'Avatar Outfit',
-		3: 'Group Membership',
-		4: 'Condo Activity',
-		5: 'Chat Messages',
-		6: 'Game Favorites',
-		7: 'Earned Badges',
-		8: 'User Creations',
-		9: 'Other Reasons'
-	},
-	GROUP_REASON_TYPE_NAMES: {
-		0: 'Member Analysis',
-		1: 'Group Purpose',
-		2: 'Group Description',
-		3: 'Group Shout'
 	}
 } as const;
 

--- a/src/lib/utils/status-utils.ts
+++ b/src/lib/utils/status-utils.ts
@@ -1,4 +1,3 @@
-import { STATUS } from '../types/constants';
 import type { UserStatus, GroupStatus } from '../types/api';
 import type { CombinedStatus } from '../types/custom-api';
 import { ROTECTOR_API_ID } from '../services/unified-query-service';
@@ -38,12 +37,12 @@ export function calculateStatusBadges(status: UserStatus | null | undefined): St
 		};
 	}
 
-	// Detect reportable status - user has description violations
-	const isReportable = !!status.reasons[STATUS.USER_REASON_TYPES.USER_PROFILE.toString()];
+	// Detect reportable status - user has User Profile violations
+	const isReportable = !!status.reasons['User Profile'];
 
 	// Detect outfit-only status - user is flagged only for outfit with no other violations
 	const reasonTypes = Object.keys(status.reasons);
-	const hasOutfitReason = reasonTypes.includes(STATUS.USER_REASON_TYPES.AVATAR_OUTFIT.toString());
+	const hasOutfitReason = reasonTypes.includes('Avatar Outfit');
 	const isOutfitOnly = hasOutfitReason && reasonTypes.length === 1 && !isReportable;
 
 	return {

--- a/src/lib/utils/violation-formatter.ts
+++ b/src/lib/utils/violation-formatter.ts
@@ -1,4 +1,3 @@
-import { ENTITY_TYPES, STATUS } from '../types/constants';
 import type { ReasonData } from '../types/api';
 
 export interface FormattedReasonEntry {
@@ -59,33 +58,15 @@ function formatEvidence(evidence: string[], isOutfitReason: boolean): FormattedE
 
 // Formats the reasons from the API response into a structured format for display
 export function formatViolationReasons(
-	reasons: Record<string, ReasonData>,
-	entityType?: string
+	reasons: Record<string, ReasonData>
 ): FormattedReasonEntry[] {
 	if (!reasons || Object.keys(reasons).length === 0) {
 		return [];
 	}
 
 	return Object.entries(reasons).map(([reasonType, reason]) => {
-		let typeName: string;
-		let isOutfitReason = false;
-
-		// Check if the reason key is numeric (Rotector format) or string-based (custom API format)
-		const numericKey = parseInt(reasonType, 10);
-		const isNumericKey = !isNaN(numericKey) && numericKey.toString() === reasonType;
-
-		if (isNumericKey) {
-			if (entityType === ENTITY_TYPES.GROUP) {
-				const reasonTypeKey = numericKey as keyof typeof STATUS.GROUP_REASON_TYPE_NAMES;
-				typeName = STATUS.GROUP_REASON_TYPE_NAMES[reasonTypeKey] || 'Other';
-			} else {
-				const reasonTypeKey = numericKey as keyof typeof STATUS.USER_REASON_TYPE_NAMES;
-				typeName = STATUS.USER_REASON_TYPE_NAMES[reasonTypeKey] || 'Other';
-				isOutfitReason = numericKey === STATUS.USER_REASON_TYPES.AVATAR_OUTFIT;
-			}
-		} else {
-			typeName = reasonType;
-		}
+		const typeName = reasonType;
+		const isOutfitReason = reasonType === 'Avatar Outfit';
 
 		const confidence = Math.round(reason.confidence * 100);
 


### PR DESCRIPTION
This change simplifies reason type handling by using descriptive string keys instead of numeric codes.