### PR TITLE
refactor(permissions): make translate API permission optional

### DIFF
--- a/src/lib/types/changelog.ts
+++ b/src/lib/types/changelog.ts
@@ -42,6 +42,11 @@ export const CHANGELOGS: Changelog[] = [
 				type: 'changed',
 				description:
 					'Status indicator colors - Pending users now display orange and mixed users display yellow for better visual distinction'
+			},
+			{
+				type: 'changed',
+				description:
+					'Translation permission - Auto-translate feature now requests permission only when enabled instead of requiring it at install'
 			}
 		]
 	},

--- a/src/lib/utils/permissions.ts
+++ b/src/lib/utils/permissions.ts
@@ -1,5 +1,17 @@
 import { logger } from './logger';
 
+const TRANSLATE_API_ORIGIN = 'https://translate.googleapis.com/*';
+
+// Check if we have permission to use the Google Translate API
+export async function hasTranslatePermission(): Promise<boolean> {
+	return hasPermissionsForOrigins([TRANSLATE_API_ORIGIN]);
+}
+
+// Request permission to use the Google Translate API
+export async function requestTranslatePermission(): Promise<boolean> {
+	return requestPermissionsForOrigins([TRANSLATE_API_ORIGIN]);
+}
+
 // Convert a full API URL to an origin pattern for permission requests
 export function extractOriginPattern(url: string): string | null {
 	try {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -52,12 +52,8 @@ export default defineConfig({
 			'Real-time warnings about inappropriate Roblox users before you interact with them.',
 		version: '2.5.1',
 		permissions: ['storage'],
-		host_permissions: [
-			'https://*.roblox.com/*',
-			`https://${apiDomain}/*`,
-			'https://translate.googleapis.com/*'
-		],
-		optional_host_permissions: ['https://*/*'],
+		host_permissions: [`https://${apiDomain}/*`],
+		optional_host_permissions: ['https://*/*', 'https://translate.googleapis.com/*'],
 		externally_connectable: {
 			matches: [`https://${apiDomain}/*`]
 		},


### PR DESCRIPTION
This commit moves the Google Translate API from required to optional permissions, requesting access only when the user enables auto-translate.