### PR TITLE
feat(i18n): add Chrome Web Store language recognition

### DIFF
--- a/public/_locales/ar/messages.json
+++ b/public/_locales/ar/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "تحذيرات فورية حول مستخدمي Roblox غير المناسبين قبل التفاعل معهم."
+	}
+}

--- a/public/_locales/bn/messages.json
+++ b/public/_locales/bn/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "অনুপযুক্ত Roblox ব্যবহারকারীদের সাথে যোগাযোগের আগে রিয়েল-টাইম সতর্কতা।"
+	}
+}

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "Echtzeit-Warnungen vor unangemessenen Roblox-Nutzern, bevor Sie mit ihnen interagieren."
+	}
+}

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "Real-time warnings about inappropriate Roblox users before you interact with them."
+	}
+}

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "Advertencias en tiempo real sobre usuarios de Roblox inapropiados antes de interactuar con ellos."
+	}
+}

--- a/public/_locales/fil/messages.json
+++ b/public/_locales/fil/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "Real-time na babala tungkol sa hindi naaangkop na mga user ng Roblox bago ka makipag-ugnayan sa kanila."
+	}
+}

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "Avertissements en temps réel sur les utilisateurs inappropriés de Roblox avant d'interactuer avec eux."
+	}
+}

--- a/public/_locales/hi/messages.json
+++ b/public/_locales/hi/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "अनुचित Roblox उपयोगकर्ताओं के बारे में वास्तविक समय चेतावनियां, इससे पहले कि आप उनके साथ इंटरैक्ट करें।"
+	}
+}

--- a/public/_locales/id/messages.json
+++ b/public/_locales/id/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "Peringatan real-time tentang pengguna Roblox yang tidak pantas sebelum Anda berinteraksi dengan mereka."
+	}
+}

--- a/public/_locales/it/messages.json
+++ b/public/_locales/it/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "Avvisi in tempo reale su utenti Roblox inappropriati prima di interagire con loro."
+	}
+}

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "不適切なRobloxユーザーとのやり取り前にリアルタイムで警告を表示します。"
+	}
+}

--- a/public/_locales/ko/messages.json
+++ b/public/_locales/ko/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "부적절한 Roblox 사용자와 상호작용하기 전에 실시간으로 경고를 표시합니다."
+	}
+}

--- a/public/_locales/ms/messages.json
+++ b/public/_locales/ms/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "Amaran masa nyata tentang pengguna Roblox yang tidak sesuai sebelum anda berinteraksi dengan mereka."
+	}
+}

--- a/public/_locales/nl/messages.json
+++ b/public/_locales/nl/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "Realtime waarschuwingen over ongepaste Roblox-gebruikers voordat je met hen interacteert."
+	}
+}

--- a/public/_locales/pl/messages.json
+++ b/public/_locales/pl/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "Ostrzeżenia w czasie rzeczywistym o nieodpowiednich użytkownikach Roblox zanim z nimi wejdziesz w interakcję."
+	}
+}

--- a/public/_locales/pt/messages.json
+++ b/public/_locales/pt/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "Avisos em tempo real sobre usuários inadequados do Roblox antes de você interagir com eles."
+	}
+}

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "Предупреждения в реальном времени о неподобающих пользователях Roblox перед взаимодействием с ними."
+	}
+}

--- a/public/_locales/sv/messages.json
+++ b/public/_locales/sv/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "Realtidsvarningar om olämpliga Roblox-användare innan du interagerar med dem."
+	}
+}

--- a/public/_locales/th/messages.json
+++ b/public/_locales/th/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "คำเตือนแบบเรียลไทม์เกี่ยวกับผู้ใช้ Roblox ที่ไม่เหมาะสมก่อนที่คุณจะโต้ตอบกับพวกเขา"
+	}
+}

--- a/public/_locales/tr/messages.json
+++ b/public/_locales/tr/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "Uygunsuz Roblox kullanıcıları hakkında onlarla etkileşime geçmeden önce gerçek zamanlı uyarılar."
+	}
+}

--- a/public/_locales/uk/messages.json
+++ b/public/_locales/uk/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "Попередження в реальному часі про неприйнятних користувачів Roblox перед тим, як ви з ними взаємодієте."
+	}
+}

--- a/public/_locales/vi/messages.json
+++ b/public/_locales/vi/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "Cảnh báo theo thời gian thực về người dùng Roblox không phù hợp trước khi bạn tương tác với họ."
+	}
+}

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "在您与不当Roblox用户互动之前提供实时警告。"
+	}
+}

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -1,0 +1,8 @@
+{
+	"extensionName": {
+		"message": "Rotector - Roblox Safety Warnings"
+	},
+	"extensionDescription": {
+		"message": "在您與不當Roblox用戶互動之前提供即時警告。"
+	}
+}

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -47,9 +47,9 @@ export default defineConfig({
 		}
 	}),
 	manifest: {
-		name: 'Rotector - Roblox Safety Warnings',
-		description:
-			'Real-time warnings about inappropriate Roblox users before you interact with them.',
+		name: '__MSG_extensionName__',
+		description: '__MSG_extensionDescription__',
+		default_locale: 'en',
 		version: '2.5.1',
 		permissions: ['storage'],
 		host_permissions: [`https://${apiDomain}/*`],


### PR DESCRIPTION
This commit adds _locales directory with manifest i18n support so Chrome Web Store recognizes all 24 supported languages in the store listing.