### PR TITLE
fix(profile): wait for group items before processing

### DIFF
--- a/src/lib/utils/observer.ts
+++ b/src/lib/utils/observer.ts
@@ -25,8 +25,6 @@ interface ListObserverConfig {
 	restartDelay?: number;
 	enablePostResizeProcessing?: boolean;
 	onResizeComplete?: () => void | Promise<void>;
-	observeAttributes?: boolean;
-	attributeFilter?: string[];
 }
 
 interface UrlChangeObserverConfig {
@@ -419,9 +417,7 @@ export const observerFactory = {
 			processExistingItems = true,
 			restartDelay = OBSERVER_CONFIG.DEFAULT_RESTART_DELAY,
 			enablePostResizeProcessing = false,
-			onResizeComplete,
-			observeAttributes = false,
-			attributeFilter
+			onResizeComplete
 		} = config;
 
 		const processItemsInContainer = async () => {
@@ -440,9 +436,7 @@ export const observerFactory = {
 			targetSelector: containerSelector,
 			observerOptions: {
 				childList: true,
-				subtree: true,
-				attributes: observeAttributes,
-				attributeFilter: observeAttributes ? attributeFilter : undefined
+				subtree: true
 			},
 			callback: () => {
 				processItemsInContainer().catch((error) => {


### PR DESCRIPTION
This adds waitForAllItems utility that polls until all items have their href attributes populated, eliminating race conditions with Angular's lazy rendering.