### PR TITLE
fix(profile): groups scan bar works with BTRoblox

### DIFF
--- a/src/components/features/profile/ProfilePageManager.svelte
+++ b/src/components/features/profile/ProfilePageManager.svelte
@@ -457,14 +457,22 @@
 		if (get(restrictedAccessStore).isRestricted && !isOwnProfile) return;
 
 		try {
-			const result = await waitForElement(PROFILE_GROUPS_SHOWCASE_SELECTORS.HEADER_TITLE);
+			const btrContainer = document.querySelector(BTROBLOX_GROUPS_SELECTORS.CONTAINER);
+			const result = btrContainer
+				? await waitForElement(BTROBLOX_GROUPS_SELECTORS.HEADER_TITLE)
+				: await waitForElement(PROFILE_GROUPS_SHOWCASE_SELECTORS.HEADER_TITLE);
 			if (!result.success) return;
 
-			// Roblox's communities-carousel parent stacks children vertically, so a sibling span lands on the next row
-			// Append inside the h2 (Roblox's own .friends-count pattern) to stay inline with the heading
 			const container = document.createElement('span');
 			container.className = COMPONENT_CLASSES.SCAN_HOST;
-			result.element.append(container);
+
+			if (btrContainer) {
+				result.element.after(container);
+			} else {
+				// Roblox's communities-carousel parent stacks children vertically, so a sibling span lands on the next row
+				// Append inside the h2 (Roblox's own .friends-count pattern) to stay inline with the heading
+				result.element.append(container);
+			}
 
 			const component = mount(GroupsScanBar, {
 				target: container,

--- a/src/components/features/profile/ProfilePageManager.svelte
+++ b/src/components/features/profile/ProfilePageManager.svelte
@@ -458,9 +458,10 @@
 
 		try {
 			const btrContainer = document.querySelector(BTROBLOX_GROUPS_SELECTORS.CONTAINER);
-			const result = btrContainer
-				? await waitForElement(BTROBLOX_GROUPS_SELECTORS.HEADER_TITLE)
-				: await waitForElement(PROFILE_GROUPS_SHOWCASE_SELECTORS.HEADER_TITLE);
+			const headerSelector = btrContainer
+				? BTROBLOX_GROUPS_SELECTORS.HEADER_TITLE
+				: PROFILE_GROUPS_SHOWCASE_SELECTORS.HEADER_TITLE;
+			const result = await waitForElement(headerSelector);
 			if (!result.success) return;
 
 			const container = document.createElement('span');

--- a/src/lib/controllers/selectors/profile.ts
+++ b/src/lib/controllers/selectors/profile.ts
@@ -24,6 +24,7 @@ export const PROFILE_GROUPS_SHOWCASE_SELECTORS = {
 // BTRoblox extension's modified groups view where the third-party DOM differs from native
 export const BTROBLOX_GROUPS_SELECTORS = {
 	CONTAINER: '.btr-profile-groups',
+	HEADER_TITLE: '.btr-profile-groups .container-header h2',
 	SECTION_CONTENT: '.section-content',
 	ITEMS_CONTAINER: '.hlist[ng-non-bindable]',
 	ITEM: '.list-item.game-card',


### PR DESCRIPTION
Thought I was going insane but BTRoblox not being covered with the recent communities scan bar update means it never showed up. Minor modifications to the code to enable the scan bar to appear for users that are also utilizing BTRoblox. 
- `src/lib/controllers/selectors/profile.ts` - added a new variable with the class name 
- `src/components/features/profile/ProfilePageManager.svelte` - added handling the BTRoblox header, defaulting to the regular Roblox class names and performing as if there were no modifications to begin with.

|Before|After|
| -------- | ------- |
|<img width="400" height="500" alt="image" src="https://github.com/user-attachments/assets/58b4c3df-1eef-41af-b242-b982a84c5ed3" />|<img width="400" height="500" alt="image" src="https://github.com/user-attachments/assets/6fae5fba-3b2b-4b41-9cef-9a8c5acd3325" />|

